### PR TITLE
Apcu #151: BC for Windows x86

### DIFF
--- a/php_apc.h
+++ b/php_apc.h
@@ -22,6 +22,19 @@
 #define PHP_APC_VERSION "5.1.2dev"
 #define PHP_APC_EXTNAME "apc"
 
+/*
+ * This module defines utilities and helper functions used elsewhere in APC.
+ */
+#ifdef PHP_WIN32
+# define PHP_APCU_API __declspec(dllexport)
+#elif defined(__GNUC__) && __GNUC__ >= 4
+# define PHP_APCU_API __attribute__ ((visibility("default")))
+#else
+# define PHP_APCU_API
+#endif
+
+PHP_APCU_API zend_class_entry* apc_iterator_ce;
+
 extern zend_module_entry apc_module_entry;
 #define apc_module_ptr &apc_module_entry
 


### PR DESCRIPTION
https://github.com/krakjoe/apcu/issues/151#issuecomment-162045049

It had nothing to do with 'apc_iterator_ce' being exportable or not. Once both extensions are loaded apc_iterator_ce is declared and valid anyway. I have no idea why x86 stumbled over it and x64 did not, but the solution is to declare 'apc_iterator_ce' the same way in php_apc.h as it is declared in the headers of the APCu extension.
