### PR TITLE
Fix pickle install adding PHP_APCU_BC_VERSION. Bump to 1.0.1.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,7 @@
  <date>2015-12-07</date>
  <time>08:00:00</time>
  <version>
-  <release>1.0.0</release>
+  <release>1.0.1</release>
   <api>5.1</api>
  </version>
  <stability>

--- a/php_apc.c
+++ b/php_apc.c
@@ -50,7 +50,7 @@ PHP_FUNCTION(apc_clear_cache);
 static PHP_MINFO_FUNCTION(apc)
 {
     php_info_print_table_start();
-    php_info_print_table_row(2, "APC Compatibility", PHP_APC_VERSION);
+    php_info_print_table_row(2, "APC Compatibility", PHP_APCU_BC_VERSION);
     php_info_print_table_row(2, "APCu Version", PHP_APCU_VERSION);
     php_info_print_table_row(2, "Build Date", __DATE__ " " __TIME__);
     php_info_print_table_end();

--- a/php_apc.h
+++ b/php_apc.h
@@ -20,7 +20,8 @@
 #define PHP_APC_H
 
 #define PHP_APC_EXTNAME "apc"
-#define PHP_APC_VERSION "1.0.1dev"
+#define PHP_APCU_BC_VERSION "1.0.1"
+#define PHP_APC_VERSION PHP_APCU_BC_VERSION
 
 extern zend_module_entry apc_module_entry;
 #define apc_module_ptr &apc_module_entry


### PR DESCRIPTION
This avoid this kind of (blocking) exception during pickle install:

```
[Exception]
  Couldn't parse the version defined in the PHP_APCU_BC_VERSION macro
```
